### PR TITLE
Fix the way paramters are handled

### DIFF
--- a/src/converter.rs
+++ b/src/converter.rs
@@ -44,12 +44,20 @@ fn replace_full_vars(arguments: &str) -> String {
         };
 
         if found {
-            buffer.push("%");
-        }
-        buffer.push(before);
-
-        if found {
-            buffer.push("%")
+            match before {
+                "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" => {
+                    buffer.push("%");
+                    buffer.push(before);
+                },
+                "@" => buffer.push("%*"),
+                _ => {
+                    buffer.push("%");
+                    buffer.push(before);
+                    buffer.push("%");
+                }
+            }
+        } else {
+            buffer.push(before)
         }
 
         if after.len() > 0 {
@@ -72,9 +80,18 @@ fn replace_partial_vars(arguments: &str) -> String {
             Some(index) => part.split_at(index),
         };
 
-        buffer.push("%");
-        buffer.push(before);
-        buffer.push("%");
+        match before {
+            "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" => {
+                buffer.push("%");
+                buffer.push(before);
+            },
+            "@" => buffer.push("%*"),
+            _ => {
+                buffer.push("%");
+                buffer.push(before);
+                buffer.push("%");
+            }
+        }
 
         if after.len() > 0 {
             buffer.push(after);

--- a/src/converter_test.rs
+++ b/src/converter_test.rs
@@ -181,6 +181,33 @@ fn replace_vars_mixed() {
 }
 
 #[test]
+fn replace_params_full() {
+    let mut value = replace_full_vars("echo 0=${0} 1=${1} 2=${2} 3=${3} 4=${4} 5=${5} 6=${6} 7=${7} 8=${8} 9=${9}");
+    assert_eq!(value, "echo 0=%0 1=%1 2=%2 3=%3 4=%4 5=%5 6=%6 7=%7 8=%8 9=%9".to_string());
+
+    value = replace_full_vars("echo ${@}");
+    assert_eq!(value, "echo %*".to_string());
+}
+
+#[test]
+fn replace_params_partial_syntax() {
+    let mut value = replace_partial_vars("echo 0=$0 1=$1 2=$2 3=$3 4=$4 5=$5 6=$6 7=$7 8=$8 9=$9");
+    assert_eq!(value, "echo 0=%0 1=%1 2=%2 3=%3 4=%4 5=%5 6=%6 7=%7 8=%8 9=%9".to_string());
+
+    value = replace_partial_vars("echo $@");
+    assert_eq!(value, "echo %*".to_string());
+}
+
+#[test]
+fn replace_params_mixed() {
+    let mut value = replace_vars("echo 0=$0 1=${1} 2=$2 3=${3} 4=$4 5=${5} 6=$6 7=${7} 8=$8 9=${9}");
+    assert_eq!(value, "echo 0=%0 1=%1 2=%2 3=%3 4=%4 5=%5 6=%6 7=%7 8=%8 9=%9".to_string());
+
+    value = replace_vars("echo $@ ${@}");
+    assert_eq!(value, "echo %* %*".to_string());
+}
+
+#[test]
 fn run_empty() {
     let output = run("");
 


### PR DESCRIPTION
Fixes #3 by special casing parameters of the form `$n`/`${n}` where `n` <= `9` and `$@`/`${@}`