### PR TITLE
Non recursive cp

### DIFF
--- a/benches/bench_convert.rs
+++ b/benches/bench_convert.rs
@@ -23,7 +23,7 @@ fn convert(bencher: &mut Bencher) {
             r#"
 
 @REM this is some test code
-xcopy file1 file2
+copy file1 file2
 
 @REM another
 move file2 file3

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -28,7 +28,7 @@ set FILE1=file1
 set FILE2=file2
 
 @REM this is some test code
-xcopy %FILE1% %FILE2%
+copy %FILE1% %FILE2%
 
 @REM another
 move file2 file3
@@ -36,7 +36,7 @@ move file2 file3
 set MY_DIR=directory
 
 @REM flags are supported
-del /Q %MY_DIR%
+rmdir /S /Q %MY_DIR%
 
 set MY_DIR=
 "#

--- a/src/converter.rs
+++ b/src/converter.rs
@@ -145,11 +145,15 @@ fn convert_line(line: &str) -> String {
                     //
                     // We can select which one to use based on the presence of
                     // the -r flag.
-                    let regex_instance = Regex::new("-[^ ]*[rR]").expect("regex to be valid");
-                    let win_cmd = if regex_instance.is_match(&arguments) {
-                        "xcopy".to_string()
-                    } else {
-                        "copy".to_string()
+                    let win_cmd = match Regex::new("-[^ ]*[rR]") {
+                        Ok(regex_instance) => {
+                            if regex_instance.is_match(&arguments) {
+                                "xcopy".to_string()
+                            } else {
+                                "copy".to_string()
+                            }
+                        }
+                        Err(_) => "del".to_string(),
                     };
 
                     let flags_mappings = if win_cmd == "xcopy".to_string() {
@@ -162,11 +166,15 @@ fn convert_line(line: &str) -> String {
                 "mv" => ("move".to_string(), vec![], vec![], true),
                 "ls" => ("dir".to_string(), vec![], vec![], true),
                 "rm" => {
-                    let regex_instance = Regex::new("-[^ ]*[rR]").expect("regex to be valid");
-                    let win_cmd = if regex_instance.is_match(&arguments) {
-                        "rmdir".to_string()
-                    } else {
-                        "del".to_string()
+                    let win_cmd = match Regex::new("-[^ ]*[rR]") {
+                        Ok(regex_instance) => {
+                            if regex_instance.is_match(&arguments) {
+                                "rmdir".to_string()
+                            } else {
+                                "del".to_string()
+                            }
+                        }
+                        Err(_) => "del".to_string(),
                     };
 
                     let flags_mappings = if win_cmd == "rmdir".to_string() {

--- a/src/converter.rs
+++ b/src/converter.rs
@@ -135,7 +135,25 @@ fn convert_line(line: &str) -> String {
 
         let (mut windows_command, flags_mappings, additional_arguments, modify_path_separator) =
             match shell_command {
-                "cp" => ("xcopy".to_string(), vec![("-[rR]", "/E")], vec![], true),
+                "cp" => {
+                    let win_cmd = match Regex::new("-[^ ]*[rR]") {
+                        Ok(regex_instance) => {
+                            if regex_instance.is_match(&arguments) {
+                                "xcopy".to_string()
+                            } else {
+                                "copy".to_string()
+                            }
+                        }
+                        Err(_) => "del".to_string(),
+                    };
+
+                    let flags_mappings = if win_cmd == "xcopy".to_string() {
+                        vec![("-[rR]", "/E")]
+                    } else {
+                        vec![]
+                    };
+                    (win_cmd, flags_mappings, vec![], true)
+                },
                 "mv" => ("move".to_string(), vec![], vec![], true),
                 "ls" => ("dir".to_string(), vec![], vec![], true),
                 "rm" => {

--- a/src/converter.rs
+++ b/src/converter.rs
@@ -153,7 +153,7 @@ fn convert_line(line: &str) -> String {
                                 "copy".to_string()
                             }
                         }
-                        Err(_) => "del".to_string(),
+                        Err(_) => "copy".to_string(),
                     };
 
                     let flags_mappings = if win_cmd == "xcopy".to_string() {

--- a/src/converter.rs
+++ b/src/converter.rs
@@ -136,6 +136,15 @@ fn convert_line(line: &str) -> String {
         let (mut windows_command, flags_mappings, additional_arguments, modify_path_separator) =
             match shell_command {
                 "cp" => {
+                    // There is no good `cp` equivalent on windows. There are
+                    // two tools we can rely on:
+                    //
+                    // - xcopy, which is great for directory to directory
+                    //   copies.
+                    // - copy, which is great for file to file/directory copies.
+                    //
+                    // We can select which one to use based on the presence of
+                    // the -r flag.
                     let win_cmd = match Regex::new("-[^ ]*[rR]") {
                         Ok(regex_instance) => {
                             if regex_instance.is_match(&arguments) {

--- a/src/converter.rs
+++ b/src/converter.rs
@@ -145,7 +145,7 @@ fn convert_line(line: &str) -> String {
                     //
                     // We can select which one to use based on the presence of
                     // the -r flag.
-                    let win_cmd = match Regex::new("-[^ ]*[rR]") {
+                    let win_cmd = match Regex::new("(^|\\s)-[^ ]*[rR]") {
                         Ok(regex_instance) => {
                             if regex_instance.is_match(&arguments) {
                                 "xcopy".to_string()

--- a/src/converter.rs
+++ b/src/converter.rs
@@ -145,15 +145,11 @@ fn convert_line(line: &str) -> String {
                     //
                     // We can select which one to use based on the presence of
                     // the -r flag.
-                    let win_cmd = match Regex::new("-[^ ]*[rR]") {
-                        Ok(regex_instance) => {
-                            if regex_instance.is_match(&arguments) {
-                                "xcopy".to_string()
-                            } else {
-                                "copy".to_string()
-                            }
-                        }
-                        Err(_) => "del".to_string(),
+                    let regex_instance = Regex::new("-[^ ]*[rR]").expect("regex to be valid");
+                    let win_cmd = if regex_instance.is_match(&arguments) {
+                        "xcopy".to_string()
+                    } else {
+                        "copy".to_string()
                     };
 
                     let flags_mappings = if win_cmd == "xcopy".to_string() {
@@ -166,15 +162,11 @@ fn convert_line(line: &str) -> String {
                 "mv" => ("move".to_string(), vec![], vec![], true),
                 "ls" => ("dir".to_string(), vec![], vec![], true),
                 "rm" => {
-                    let win_cmd = match Regex::new("-[^ ]*[rR]") {
-                        Ok(regex_instance) => {
-                            if regex_instance.is_match(&arguments) {
-                                "rmdir".to_string()
-                            } else {
-                                "del".to_string()
-                            }
-                        }
-                        Err(_) => "del".to_string(),
+                    let regex_instance = Regex::new("-[^ ]*[rR]").expect("regex to be valid");
+                    let win_cmd = if regex_instance.is_match(&arguments) {
+                        "rmdir".to_string()
+                    } else {
+                        "del".to_string()
                     };
 
                     let flags_mappings = if win_cmd == "rmdir".to_string() {

--- a/src/converter_test.rs
+++ b/src/converter_test.rs
@@ -299,6 +299,13 @@ fn convert_line_cp_recursive() {
 }
 
 #[test]
+fn convert_line_cp_file_with_dash() {
+    let output = convert_line("cp file-r directory");
+
+    assert_eq!(output, "copy file-r directory");
+}
+
+#[test]
 fn convert_line_mv() {
     let output = convert_line("mv dir/file1 dir/file2");
 

--- a/src/converter_test.rs
+++ b/src/converter_test.rs
@@ -236,7 +236,7 @@ fn run_comment() {
 fn run_command() {
     let output = run("cp file1 file2");
 
-    assert_eq!(output, "xcopy file1 file2");
+    assert_eq!(output, "copy file1 file2");
 }
 
 #[test]
@@ -255,7 +255,7 @@ fn run_multi_line() {
         r#"
 
 @REM this is some test code
-xcopy file1 file2
+copy file1 file2
 
 @REM another
 move file2 file3
@@ -288,7 +288,7 @@ fn convert_line_comment() {
 fn convert_line_cp() {
     let output = convert_line("cp dir/file1 dir/file2");
 
-    assert_eq!(output, "xcopy dir\\file1 dir\\file2");
+    assert_eq!(output, "copy dir\\file1 dir\\file2");
 }
 
 #[test]
@@ -297,6 +297,23 @@ fn convert_line_cp_recursive() {
 
     assert_eq!(output, "xcopy /E directory\\sub1 director\\sub2");
 }
+
+#[test]
+#[ignore] // Multiple arguments are currently broken.
+fn convert_line_cp_multiple() {
+    let output = convert_line("cp -r dir/file1 dir/file2 dir2/");
+
+    assert_eq!(output, "for %I in (dir\\file1 dir\\file2) do copy %I dir2\\");
+}
+
+#[test]
+#[ignore] // Multiple arguments are currently broken.
+fn convert_line_cp_multiple_recursive() {
+    let output = convert_line("cp -r dir\\sub1 dir\\sub2 dir2\\sub3");
+
+    assert_eq!(output, "for %I in (dir\\file1 dir\\file2) do xcopy /E %I dir2\\");
+}
+
 
 #[test]
 fn convert_line_mv() {

--- a/src/converter_test.rs
+++ b/src/converter_test.rs
@@ -299,23 +299,6 @@ fn convert_line_cp_recursive() {
 }
 
 #[test]
-#[ignore] // Multiple arguments are currently broken.
-fn convert_line_cp_multiple() {
-    let output = convert_line("cp -r dir/file1 dir/file2 dir2/");
-
-    assert_eq!(output, "for %I in (dir\\file1 dir\\file2) do copy %I dir2\\");
-}
-
-#[test]
-#[ignore] // Multiple arguments are currently broken.
-fn convert_line_cp_multiple_recursive() {
-    let output = convert_line("cp -r dir\\sub1 dir\\sub2 dir2\\sub3");
-
-    assert_eq!(output, "for %I in (dir\\file1 dir\\file2) do xcopy /E %I dir2\\");
-}
-
-
-#[test]
 fn convert_line_mv() {
     let output = convert_line("mv dir/file1 dir/file2");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,7 +142,7 @@
 //! set FILE2=file2
 //!
 //! @REM this is some test code
-//! xcopy %FILE1% %FILE2%
+//! copy %FILE1% %FILE2%
 //!
 //! @REM another
 //! move file2 file3
@@ -211,7 +211,7 @@ mod converter;
 /// set FILE2=file2
 ///
 /// @REM this is some test code
-/// xcopy %FILE1% %FILE2%
+/// copy %FILE1% %FILE2%
 ///
 /// @REM another
 /// move file2 file3

--- a/src/lib_test.rs
+++ b/src/lib_test.rs
@@ -18,7 +18,7 @@ fn convert_comment() {
 fn convert_command() {
     let output = convert("cp file1 file2");
 
-    assert_eq!(output, "xcopy file1 file2".to_string());
+    assert_eq!(output, "copy file1 file2".to_string());
 }
 
 #[test]
@@ -40,7 +40,7 @@ fn convert_multi_line() {
         output,
         r#"
 @REM this is some test code
-xcopy file1 file2
+copy file1 file2
 
 @REM another
 move file2 file3

--- a/tests/convert_test.rs
+++ b/tests/convert_test.rs
@@ -29,7 +29,7 @@ set FILE1=file1
 set FILE2=file2
 
 @REM this is some test code
-xcopy %FILE1% %FILE2%
+copy %FILE1% %FILE2%
 
 @REM another
 move file2 file3


### PR DESCRIPTION
Initial fix for non-recursive cp.

This doesn't work for multiple file copies yet though. For this, we'd need some way to generate a for loop with the arguments. E.G. `cp test1 test2 test3` should generate `for %I in (test1 test2) do copy %I test3`. Two things necessary for this:

1. We need a way to gather non-flag arguments - probably a simple regex of `\b[^-]+` will do?
2. Where do we insert the for loop? I suspect somewhere just before or after handling the flag replacement.